### PR TITLE
Add lookahead and target options

### DIFF
--- a/Model_8.1
+++ b/Model_8.1
@@ -108,6 +108,18 @@ def parse_args():
         default=0.8,
         help="Cumulative importance threshold for feature selection",
     )
+    parser.add_argument(
+        "--lookahead-days",
+        type=int,
+        default=5,
+        help="Days to look ahead when generating the Target column",
+    )
+    parser.add_argument(
+        "--target-pct",
+        type=float,
+        default=0.02,
+        help="Percent rise threshold for classifying Target=1",
+    )
     return parser.parse_args()
 
 # ───────── data cache helper ─────────
@@ -136,9 +148,16 @@ def download_or_load_prices(tickers):
 
 # ───────── feature engineering ─────────
 
-def compute_features(df, market):
-    df = df.dropna(subset=["Close","High","Low","Open","Volume"]).copy()
-    df["Target"] = (df["Close"].shift(-5) >= df["Close"]*1.02).astype(int)
+def compute_features(
+    df,
+    market,
+    lookahead_days: int = 5,
+    target_pct: float = 0.02,
+):
+    df = df.dropna(subset=["Close", "High", "Low", "Open", "Volume"]).copy()
+    df["Target"] = (
+        df["Close"].shift(-lookahead_days) >= df["Close"] * (1 + target_pct)
+    ).astype(int)
     df["RSI"] = ta.momentum.rsi(df["Close"], 14)
     df["MACD"] = ta.trend.macd(df["Close"], 26, 12)
     df["MACD_SIGNAL"] = ta.trend.macd_signal(df["Close"], 26, 12, 9)
@@ -165,7 +184,11 @@ def compute_features(df, market):
     df["RS_Market"] = (df["Close"] / df["Close"].shift(20)) / (spy / spy.shift(20))
     return df.dropna()
 
-def data_prep_and_feature_engineering(threshold: float = 0.8):
+def data_prep_and_feature_engineering(
+    threshold: float = 0.8,
+    lookahead_days: int = 5,
+    target_pct: float = 0.02,
+):
     """Download prices, compute features and return selected training data."""
     ALL_TICKERS = TICKERS + ["SPY", "^VIX"]
     prices = download_or_load_prices(ALL_TICKERS)
@@ -179,7 +202,10 @@ def data_prep_and_feature_engineering(threshold: float = 0.8):
 
     print("⚙️  Computing features …")
     feat_list = Parallel(n_jobs=N_JOBS)(
-        delayed(compute_features)(price_dict[tkr], market_dict) for tkr in TICKERS
+        delayed(compute_features)(
+            price_dict[tkr], market_dict, lookahead_days, target_pct
+        )
+        for tkr in TICKERS
     )
     all_data = pd.concat(feat_list, keys=TICKERS)
     all_data.index.names = ["Date", "Symbol"]
@@ -494,7 +520,11 @@ def main():
     run_all = not (args.grid_search or args.backtest or args.update_sheets)
 
     if args.grid_search or run_all:
-        X_train_sel, y_train = data_prep_and_feature_engineering(args.feat_threshold)
+        X_train_sel, y_train = data_prep_and_feature_engineering(
+            args.feat_threshold,
+            args.lookahead_days,
+            args.target_pct,
+        )
         run_grid_search(X_train_sel, y_train, args.n_trials)
 
     if args.backtest or run_all:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -71,7 +71,7 @@ def test_compute_features_basic():
     })
     market = {'SPY': close, '^VIX': pd.Series(10.0, index=dates)}
 
-    result = model.compute_features(df, market)
+    result = model.compute_features(df, market, 5, 0.02)
     # 50‑day indicators drop the first 49 rows
     assert len(result) == len(dates) - 49
     for col in model.FEATURES + ['Target']:


### PR DESCRIPTION
## Summary
- parse CLI args for `--lookahead-days` and `--target-pct`
- compute the `Target` column with these parameters
- pass options to feature engineering helpers
- adjust unit tests for new compute_features interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f68232a08322a354eafcdd7b54f1