### PR TITLE
Add more technical features

### DIFF
--- a/Model_8.1
+++ b/Model_8.1
@@ -52,9 +52,33 @@ END_DATE = dt.date.today()
 START_DATE = END_DATE - dt.timedelta(days=YEARS*365)
 
 FEATURES = [
-    "RSI","MACD","MACD_SIGNAL","SMA_10","SMA_50","EMA_10","EMA_50","SMA_ratio","MFI","ATR",
-    "BOLL_HBAND","BOLL_LBAND","BOLL_WIDTH","Return_1d","Return_5d","Return_10d","Return_20d",
-    "Volatility_10d","Volatility_20d","SPY_Trend","VIX_Level","VIX_Change","RS_Market"
+    "RSI",
+    "MACD",
+    "MACD_SIGNAL",
+    "SMA_10",
+    "SMA_50",
+    "EMA_10",
+    "EMA_50",
+    "SMA_ratio",
+    "MFI",
+    "ATR",
+    "BOLL_HBAND",
+    "BOLL_LBAND",
+    "BOLL_WIDTH",
+    "Return_1d",
+    "Return_5d",
+    "Return_10d",
+    "Return_20d",
+    "Volatility_10d",
+    "Volatility_20d",
+    "SPY_Trend",
+    "VIX_Level",
+    "VIX_Change",
+    "RS_Market",
+    "OBV",
+    "SMA_200",
+    "Close_SMA_200",
+    "Price_Pctl_90",
 ]
 N_JOBS = -1
 
@@ -171,6 +195,12 @@ def compute_features(
     df["BOLL_HBAND"] = bb.bollinger_hband()
     df["BOLL_LBAND"] = bb.bollinger_lband()
     df["BOLL_WIDTH"] = (df["BOLL_HBAND"] - df["BOLL_LBAND"]) / df["Close"]
+    df["OBV"] = ta.volume.on_balance_volume(df["Close"], df["Volume"])
+    df["SMA_200"] = ta.trend.sma_indicator(df["Close"], 200)
+    df["Close_SMA_200"] = df["Close"] / df["SMA_200"]
+    df["Price_Pctl_90"] = df["Close"].rolling(90).apply(
+        lambda x: pd.Series(x).rank(pct=True).iloc[-1]
+    )
     for w in (1,5,10,20):
         df[f"Return_{w}d"] = df["Close"].pct_change(w)
     df["Volatility_10d"] = df["Close"].pct_change().rolling(10).std()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -60,8 +60,8 @@ def load_model():
 
 def test_compute_features_basic():
     model = load_model()
-    dates = pd.date_range('2020-01-01', periods=70, freq='D')
-    close = pd.Series(np.linspace(100, 169, len(dates)), index=dates)
+    dates = pd.date_range('2020-01-01', periods=250, freq='D')
+    close = pd.Series(np.linspace(100, 349, len(dates)), index=dates)
     df = pd.DataFrame({
         'Open': close - 1,
         'High': close + 1,
@@ -72,8 +72,8 @@ def test_compute_features_basic():
     market = {'SPY': close, '^VIX': pd.Series(10.0, index=dates)}
 
     result = model.compute_features(df, market, 5, 0.02)
-    # 50‑day indicators drop the first 49 rows
-    assert len(result) == len(dates) - 49
+    # Longest window (200‑day SMA) drops the first 199 rows
+    assert len(result) == len(dates) - 199
     for col in model.FEATURES + ['Target']:
         assert col in result.columns
     assert not result.isna().any().any()


### PR DESCRIPTION
## Summary
- compute OBV, 200-day SMA, Close/SMA_200 and price percentile over 90 days
- include the new features in `FEATURES`
- adjust feature computation unit test for longer history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ff3f99788322ac5248137d76108c