### PR TITLE
Fix argument parsing

### DIFF
--- a/Model_8.1
+++ b/Model_8.1
@@ -143,7 +143,8 @@ def parse_args():
         default=0.02,
         help="Percent rise threshold for classifying Target=1",
     )
-    return parser.parse_args()
+    args, _ = parser.parse_known_args()
+    return args
 
 # ───────── data cache helper ─────────
 


### PR DESCRIPTION
## Summary
- allow unrecognized CLI args when parsing options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68811c3dc8088322a019ca5231ffa462