### PR TITLE
Fix ARTEFACT_FILE when __file__ missing

### DIFF
--- a/Model_8.1
+++ b/Model_8.1
@@ -371,7 +371,10 @@ pip install vectorbt pandas numpy matplotlib joblib plotly kaleido
 Vectorbt uses Numba under‑the‑hood; if you have a CUDA GPU and numba‑cuda, it will JIT on GPU.
 """
 
-ARTEFACT_FILE = Path(__file__).with_name("ml_pipeline.joblib")  # created by kernel 1
+try:
+    ARTEFACT_FILE = Path(__file__).with_name("ml_pipeline.joblib")  # created by kernel 1
+except NameError:  # __file__ may be undefined
+    ARTEFACT_FILE = Path.cwd() / "ml_pipeline.joblib"
 INIT_CASH = 100_000
 MAX_POS_PCT = 0.10          # 10 % of NAV per trade
 STOP_LOSS_PCT = 0.05        # hard stop


### PR DESCRIPTION
## Summary
- allow Model_8.1 to set `ARTEFACT_FILE` even when `__file__` is unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688767815bb08322bd547e2e74500676