### PR TITLE
Fix flake8 warnings in tests

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -31,15 +31,21 @@ def load_model():
     gspread.WorksheetNotFound = type('WorksheetNotFound', (Exception,), {})
     gspread.authorize = lambda creds: None
     gspread.exceptions = types.SimpleNamespace(APIError=Exception)
+
     class DummyCreds:
         pass
-    sys.modules['google.auth'].default = lambda scopes=None: (DummyCreds(), None)
+
+    sys.modules['google.auth'].default = (
+        lambda scopes=None: (DummyCreds(), None)
+    )
     matplotlib_pyplot = types.ModuleType('matplotlib.pyplot')
     sys.modules['matplotlib.pyplot'] = matplotlib_pyplot
     backoff = sys.modules['backoff']
+
     def on_exception(*args, **kwargs):
         def decorator(fn):
             return fn
+
         return decorator
     backoff.on_exception = on_exception
     backoff.expo = lambda *a, **k: None
@@ -64,25 +70,35 @@ def load_model():
     sys.modules['ta.volume'] = ta.volume
     ta.momentum.rsi = lambda s, n=14: pd.Series(50, index=s.index)
     ta.trend.macd = lambda s, slow, fast: pd.Series(0, index=s.index)
-    ta.trend.macd_signal = lambda s, slow, fast, signal: pd.Series(0, index=s.index)
+    ta.trend.macd_signal = lambda s, slow, fast, signal: pd.Series(
+        0, index=s.index
+    )
     ta.trend.sma_indicator = lambda s, n: s.rolling(n).mean()
     ta.trend.ema_indicator = lambda s, n: s.ewm(span=n, adjust=False).mean()
-    ta.volume.money_flow_index = lambda h, l, c, v, n: pd.Series(0, index=c.index)
+    ta.volume.money_flow_index = lambda high, low, close, volume, n: pd.Series(
+        0, index=close.index
+    )
     ta.volume.on_balance_volume = lambda c, v: v.cumsum()
+
     class DummyBB:
         def __init__(self, close, window, n):
             self.close = close
             self.window = window
             self.n = n
+
         def bollinger_hband(self):
             m = self.close.rolling(self.window).mean()
             s = self.close.rolling(self.window).std()
             return m + self.n * s
+
         def bollinger_lband(self):
             m = self.close.rolling(self.window).mean()
             s = self.close.rolling(self.window).std()
             return m - self.n * s
-    ta.volatility.average_true_range = lambda h, l, c, n: pd.Series(0, index=c.index)
+
+    ta.volatility.average_true_range = lambda h, low, c, n: pd.Series(
+        0, index=c.index
+    )
     ta.volatility.BollingerBands = DummyBB
     # load module
     loader = importlib.machinery.SourceFileLoader('model', str(path))
@@ -127,16 +143,20 @@ def test_update_equity_tracker_appends(monkeypatch, tmp_path):
     class DummyWS:
         def __init__(self):
             self.rows = []
+
         def append_rows(self, rows, value_input_option=None):
             self.rows.extend(rows)
             appended.extend(rows)
+
         def col_values(self, idx):
-            return [r[idx-1] for r in self.rows]
+            return [r[idx - 1] for r in self.rows]
+
         def cell(self, r, c):
             class C:
                 pass
+
             cell = C()
-            cell.value = self.rows[r-1][c-1]
+            cell.value = self.rows[r - 1][c - 1]
             return cell
 
     ws = DummyWS()
@@ -144,13 +164,18 @@ def test_update_equity_tracker_appends(monkeypatch, tmp_path):
     class Sheet:
         def worksheet(self, title):
             return ws
+
         def add_worksheet(self, title, rows='100', cols='3'):
             return ws
 
     monkeypatch.setattr(model, 'get_sheet', lambda: Sheet())
     monkeypatch.setattr(model, '_ensure_worksheet', lambda sheet, title: ws)
     monkeypatch.setattr(model, '_last_row', lambda ws: len(ws.rows))
-    monkeypatch.setattr(model, '_append_rows', lambda ws_, rows: ws_.append_rows(rows))
+    monkeypatch.setattr(
+        model,
+        '_append_rows',
+        lambda ws_, rows: ws_.append_rows(rows),
+    )
 
     class FixedDate(dt.date):
         @classmethod


### PR DESCRIPTION
## Summary
- clean up nested definitions and long lines in `tests/test_model.py`
- rename ambiguous variable names
- keep flake8 happy

## Testing
- `flake8 tests/test_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688768579b5c83228bb4f0f7502ef523